### PR TITLE
Removing inline

### DIFF
--- a/src/Canvas.h
+++ b/src/Canvas.h
@@ -10,7 +10,7 @@
 #ifndef _CANVAS_H_
 #define _CANVAS_H_
 
-#include "Color.h" // Each pixel is a color 
+#include "Color.h" // Each pixel is a color
 #include <cstdio>
 #include <cstring>
 
@@ -23,7 +23,7 @@ public:
     for(int i = 0; i < height_; i++) {
       canvas_[i] = new Color[width_];
     }
-  } 
+  }
 
   // Destructor:
   ~Canvas() {
@@ -50,13 +50,13 @@ public:
       sprintf(header, HEADER_TEMPLATE, width_, height_);
 
       // Write the header
-      fwrite(header, 1, strlen(header), output); 
+      fwrite(header, 1, strlen(header), output);
 
       /*
        * The data is as follows:
        * R G B
        *
-       * where R, G, B are scaled from 0 to 255. 
+       * where R, G, B are scaled from 0 to 255.
        */
       for(int y = 0; y < height_; ++y) {
         for(int x = 0; x < width_; ++x) {
@@ -65,27 +65,27 @@ public:
           int scaledRed = ScaleColorValue(nextColor.Red());
           int scaledGreen = ScaleColorValue(nextColor.Green());
           int scaledBlue = ScaleColorValue(nextColor.Blue());
-                
+
           char nextColorBody[100] = {0};
           const char *COLOR_TEMPLATE = "%d %d %d ";
           sprintf(nextColorBody, COLOR_TEMPLATE, scaledRed, scaledGreen, scaledBlue);
-                     
+
           fwrite(nextColorBody, 1, strlen(nextColorBody), output);
         }
-      }  
+      }
       fwrite("\n", 1, 1, output);
       fclose(output);
     }
-  } 
-
-  // Accessor/Modifier functions
-  inline int GetWidth() const { return width_; }
-  inline int GetHeight() const { return height_; }
-  inline Color PixelAt( const int x, const int y ) const { 
-    return canvas_[y][x]; 
   }
 
-  inline void WritePixel(const int x, const int y, const Color& color) {
+  // Accessor/Modifier functions
+  int GetWidth() const { return width_; }
+  int GetHeight() const { return height_; }
+  Color PixelAt( const int x, const int y ) const {
+    return canvas_[y][x];
+  }
+
+  void WritePixel(const int x, const int y, const Color& color) {
     // Ensure the pixel value is accessible
     if((x > 0) && (x < width_) &&
        (y > 0) && (y < height_)) {
@@ -95,7 +95,7 @@ public:
 
 private:
   // Scale the RGB color values from (0.0-1.0) to (0-255)
-  int ScaleColorValue( const float colorValue ) const {
+  int ScaleColorValue(const float colorValue) const {
     float clr = colorValue;
     // Threshold the input color value to be between 0.0-1.0
     if (clr > 1.0) {
@@ -103,8 +103,8 @@ private:
     } else if (clr < 0.0) {
       clr = 0.0;
     }
-    return static_cast<int>(255 * clr);   
-  }     
+    return static_cast<int>(255 * clr);
+  }
 
   // Canvas dimensions
   int width_, height_;

--- a/src/Color.h
+++ b/src/Color.h
@@ -12,22 +12,22 @@
 
 #include "Tuple.h"
 
-// Color is built on top of a Tuple 
+// Color is built on top of a Tuple
 class Color : public Tuple
 {
 public:
   // Default Constructor (defaults to black)
   Color() : Tuple(0.0, 0.0, 0.0, 0.0) {
   }
- 
+
   Color(const float red, const float green, const float blue) :
     Tuple(red, green, blue, 0.0) {
   }
 
   // Accessors/Modifiers.  We don't need the m_w parameter.
-  inline float Red()   const { return x_; }
-  inline float Green() const { return y_; }
-  inline float Blue()  const { return z_; }
+  float Red()   const { return x_; }
+  float Green() const { return y_; }
+  float Blue()  const { return z_; }
 
   // Comparison operator ==
   bool operator==(const Color &rhs) const {

--- a/src/Material.h
+++ b/src/Material.h
@@ -16,7 +16,7 @@
 class Material {
 public:
   /**
-   * @brief Default Constructor 
+   * @brief Default Constructor
    */
   Material() :
     color_(Color(1, 1, 1)),
@@ -70,18 +70,18 @@ public:
   }
 
   // Accessor functions
-  inline Color GetColor() const { return color_; }
-  inline float Ambient() const { return ambient_; }
-  inline float Diffuse() const { return diffuse_; }
-  inline float Specular() const { return specular_; }
-  inline float Shininess() const { return shininess_; }
+  Color GetColor() const { return color_; }
+  float Ambient() const { return ambient_; }
+  float Diffuse() const { return diffuse_; }
+  float Specular() const { return specular_; }
+  float Shininess() const { return shininess_; }
 
   // Modifier functions
-  inline void SetColor(const Color &clr) { color_ = clr; }
-  inline void SetAmbient(const float amb) { ambient_ = amb; }
-  inline void SetDiffuse(const float dif) { diffuse_ = dif; }
-  inline void SetSpecular(const float spec) { specular_ = spec; }
-  inline void SetShininess(const float shi) { shininess_ = shi; }
+  void SetColor(const Color &clr) { color_ = clr; }
+  void SetAmbient(const float amb) { ambient_ = amb; }
+  void SetDiffuse(const float dif) { diffuse_ = dif; }
+  void SetSpecular(const float spec) { specular_ = spec; }
+  void SetShininess(const float shi) { shininess_ = shi; }
 
 private:
   /**
@@ -104,6 +104,6 @@ private:
   float specular_;
 
   // Shininess
-  float shininess_; 
+  float shininess_;
 };
 #endif

--- a/src/Matrix.h
+++ b/src/Matrix.h
@@ -141,13 +141,13 @@ public:
   }
 
   // Accessor/modifier functions
-  inline int GetRows() const { return rows_; }
-  inline int GetCols() const { return cols_; }
-  inline float GetValue(const int y, const int x) const {
+  int GetRows() const { return rows_; }
+  int GetCols() const { return cols_; }
+  float GetValue(const int y, const int x) const {
     return matrix_[y * cols_ + x];
   }
 
-  inline void SetValue(const int y, const int x, const float val) {
+  void SetValue(const int y, const int x, const float val) {
     matrix_[y * cols_ + x] = val;
   }
 private:

--- a/src/PointLight.h
+++ b/src/PointLight.h
@@ -6,7 +6,7 @@
  * Class implementation for a point light source.
  *
  * Bryant Pong
- * 12/25/19 
+ * 12/25/19
  */
 #include "Color.h"
 #include "Tuple.h"
@@ -30,7 +30,7 @@ public:
    * @brief Copy Constructor
    */
   PointLight(const PointLight &rhs) :
-    position_(rhs.position_), intensity_(rhs.intensity_) { 
+    position_(rhs.position_), intensity_(rhs.intensity_) {
   }
 
   /**
@@ -46,8 +46,8 @@ public:
   }
 
   // Accessor functions
-  inline Tuple Position() const { return position_; }
-  inline Color Intensity() const { return intensity_; }
+  Tuple Position() const { return position_; }
+  Color Intensity() const { return intensity_; }
 private:
   // A point light source has a position and an intensity/color:
   Tuple position_;

--- a/src/RaySphere.h
+++ b/src/RaySphere.h
@@ -47,19 +47,19 @@ public:
 
   /**
    * @brief Assignment operator=
-   */  
+   */
   Ray &operator=(const Ray &rhs) {
     // Check for self-assignment:
     if (this != &rhs) {
       origin_ = rhs.origin_;
       dir_ = rhs.dir_;
-    } 
+    }
     return *this;
   }
 
   // Accessor Functions
-  inline Tuple Origin() const { return origin_; }
-  inline Tuple Direction() const { return dir_; }
+  Tuple Origin() const { return origin_; }
+  Tuple Direction() const { return dir_; }
 
 private:
   // A ray has an origin point and a direction
@@ -76,7 +76,7 @@ public:
    *         around the origin and with a radius of 1.0.  Default
    *         transformation is the 4x4 identity matrix.
    */
-  Sphere() : origin_(Point(0, 0, 0)), 
+  Sphere() : origin_(Point(0, 0, 0)),
              radius_(1.0),
              id_(GenerateUniqueID()),
              transform_(Identity(4)),
@@ -90,10 +90,10 @@ public:
   }
 
   /**
-   * @brief Copy Constructor 
+   * @brief Copy Constructor
    */
   Sphere(const Sphere &rhs) :
-    origin_(rhs.origin_), 
+    origin_(rhs.origin_),
     radius_(rhs.radius_),
     id_(rhs.id_),
     transform_(rhs.transform_),
@@ -134,20 +134,20 @@ public:
   Tuple NormalAt(const Tuple &pt) const {
     const Tuple OBJECT_PT = Inverse(transform_) * pt;
     const Tuple OBJECT_NORMAL = OBJECT_PT - Point(0, 0, 0);
-    Tuple worldNormal = Transpose(Inverse(transform_)) * OBJECT_NORMAL;    
+    Tuple worldNormal = Transpose(Inverse(transform_)) * OBJECT_NORMAL;
     worldNormal.SetW(0);
-    return Normalize(worldNormal); 
+    return Normalize(worldNormal);
   }
 
   // Accessor functions
-  inline Tuple Origin() const { return origin_; }
-  inline float Radius() const { return radius_; }  
-  inline int ID() const { return id_; }
-  inline Matrix Transform() const { return transform_; }
-  inline Material GetMaterial() const { return material_; }
+  Tuple Origin() const { return origin_; }
+  float Radius() const { return radius_; }
+  int ID() const { return id_; }
+  Matrix Transform() const { return transform_; }
+  Material GetMaterial() const { return material_; }
 
-  inline void SetTransform(const Matrix &trans) { transform_ = trans; }
-  inline void SetMaterial(const Material &mat) { material_ = mat; }
+  void SetTransform(const Matrix &trans) { transform_ = trans; }
+  void SetMaterial(const Material &mat) { material_ = mat; }
 private:
   // Floating comparison
   bool IsEqual(const float num1, const float num2) const {
@@ -155,7 +155,7 @@ private:
   }
 
   // Helper function to generate a unique ID each time this is called
-  inline int GenerateUniqueID() const {
+  int GenerateUniqueID() const {
     static int nextID = 0;
     ++nextID;
     return nextID - 1;
@@ -190,7 +190,7 @@ public:
   }
 
   /**
-   * Destructor 
+   * Destructor
    */
   ~Intersection() {
   }
@@ -218,12 +218,12 @@ public:
    * Comparison operator==
    */
   bool operator==(const Intersection &rhs) const {
-    return IsEqual(t_, rhs.t_) && (object_ == rhs.object_); 
+    return IsEqual(t_, rhs.t_) && (object_ == rhs.object_);
   }
 
   // Accessors
-  inline float T() const { return t_; }
-  inline Sphere Object() const { return object_; }
+  float T() const { return t_; }
+  Sphere Object() const { return object_; }
 
 private:
   // Helper to compare floating points
@@ -235,8 +235,8 @@ private:
   float t_;
 
   // And the object the intersection hits
-  Sphere object_; 
-}; 
+  Sphere object_;
+};
 
 // Function Prototypes
 Tuple Position(const Ray &, const float);
@@ -340,15 +340,15 @@ Intersection Hit(const std::vector<Intersection> &intersects) {
 
   // Iterate through all intersections
   for (size_t i = 0; i < intersects.size(); ++i) {
-    // The hit is the intersection with the smallest positive t_ value 
+    // The hit is the intersection with the smallest positive t_ value
     if (intersects[i].T() >= 0.0 && intersects[i].T() < smallestT) {
       smallestT = intersects[i].T();
       hit = intersects[i];
     }
   }
 
-  return hit; 
-} 
+  return hit;
+}
 
 /**
  * @brief  Applies the transformation matrix to the specified ray.
@@ -356,7 +356,7 @@ Intersection Hit(const std::vector<Intersection> &intersects) {
 Ray Transform(const Ray &ray, const Matrix &transform) {
   // Apply transformation to both the ray's origin and direction:
   const Tuple TRANSFORMED_ORIGIN    = transform * ray.Origin();
-  const Tuple TRANSFORMED_DIRECTION = transform * ray.Direction();  
+  const Tuple TRANSFORMED_DIRECTION = transform * ray.Direction();
 
   return Ray(TRANSFORMED_ORIGIN, TRANSFORMED_DIRECTION);
 }

--- a/src/Tuple.h
+++ b/src/Tuple.h
@@ -127,18 +127,18 @@ public:
     }
 
     // Accessors/Modifiers:
-    inline float X() const { return x_; }
-    inline float Y() const { return y_; }
-    inline float Z() const { return z_; }
-    inline float W() const { return w_; }
+    float X() const { return x_; }
+    float Y() const { return y_; }
+    float Z() const { return z_; }
+    float W() const { return w_; }
 
-    inline void SetX(const float x) { x_ = x; }
-    inline void SetY(const float y) { y_ = y; }
-    inline void SetZ(const float z) { z_ = z; }
-    inline void SetW(const float w) { w_ = w; }
+    void SetX(const float x) { x_ = x; }
+    void SetY(const float y) { y_ = y; }
+    void SetZ(const float z) { z_ = z; }
+    void SetW(const float w) { w_ = w; }
 
-    inline bool IsPoint() const { return IsEqual(w_, 1.0); }
-    inline bool IsVector() const { return IsEqual(w_, 0.0); }
+    bool IsPoint() const { return IsEqual(w_, 1.0); }
+    bool IsVector() const { return IsEqual(w_, 0.0); }
 
 protected:
     // Comparing floating point numbers with each other safely:


### PR DESCRIPTION
This commit removes the `inline` keyword, as class member functions are implicitly inlined.

Signed-off-by: Bryant Pong <rcxking@gmail.com>